### PR TITLE
Remove sourceURL

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,8 +218,7 @@ class Workspace extends vscode_helpers.WorkspaceBase {
             if (!CFG_OPTS.inlineMap && CFG_OPTS.sourceMap) {
                 js += `
 
-//# sourceMappingURL=${ SOURCE_MAP_FILE_NAME }
-//# sourceURL=coffeescript`;
+//# sourceMappingURL=${ SOURCE_MAP_FILE_NAME }`;
             }
             
             // write JavaScript file


### PR DESCRIPTION
It doesn't seem to need `sourceURL`. It just makes Google Chrome think that every compiled coffeescript file is the same.
It works fine without it, so I removed it.
Fixes issue #2 .